### PR TITLE
Add find_packages() to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "Topic :: Software Development :: Testing"
     ],
     python_requires='>=3.5.3',
-    packages=setuptools.find_packages('.')
+    packages=setuptools.find_packages('.', exclude=("examples",))
 )

--- a/setup.py
+++ b/setup.py
@@ -23,4 +23,5 @@ setuptools.setup(
         "Topic :: Software Development :: Testing"
     ],
     python_requires='>=3.5.3',
+    packages=setuptools.find_packages('.')
 )


### PR DESCRIPTION
In the current state of the package, `pip install pythonfuzz` results in an empty install: the package and its dependencies are indeed downloaded and there are no error, but no "pythonfuzz" package is created anywhere in the `PYTHONPATH`. As a consequence, `import pythonfuzz` results in an ImportError.

You can easily miss that if you tried to import it in your project directory, as the current dir is always part of the `PYTHONPATH` and so it would seem it works for you.

However, nobody else can pip install then use PythonFuzz.

I just added a line in the setup.py that tells it to recursively find all importable packages except "examples" in the main directory. You'll need to upload this new version on pypi.org.