### PR TITLE
Add support for dictionary files

### DIFF
--- a/pythonfuzz/dictionnary.py
+++ b/pythonfuzz/dictionnary.py
@@ -1,0 +1,28 @@
+import random
+import re
+import os
+
+class Dictionary:
+    line_re = re.compile('"(.+)"$')
+
+    def __init__(self, dict_path=None):
+        if not dict_path or not os.path.exists(dict_path):
+            self._dict = list()
+            return
+
+        _dict = set()
+        with open(dict_path) as f:
+            for line in f:
+                line = line.lstrip()
+                if line.startswith('#'):
+                    continue
+                word = self.line_re.search(line)
+                if word:
+                    _dict.add(word.group(1))
+        self._dict = list(_dict)
+
+    def get_word(self):
+        if not self._dict:
+            return None
+        return random.choice(self._dict)
+

--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -42,14 +42,15 @@ class Fuzzer(object):
                  rss_limit_mb=2048,
                  timeout=120,
                  regression=False,
-                 max_input_size=4096):
+                 max_input_size=4096,
+                 dict_path=None):
         self._target = target
         self._dirs = [] if dirs is None else dirs
         self._exact_artifact_path = exact_artifact_path
         self._rss_limit_mb = rss_limit_mb
         self._timeout = timeout
         self._regression = regression
-        self._corpus = corpus.Corpus(self._dirs, max_input_size)
+        self._corpus = corpus.Corpus(self._dirs, max_input_size, dict_path)
         self._total_executions = 0
         self._executions_in_sample = 0
         self._last_sample_time = time.time()

--- a/pythonfuzz/main.py
+++ b/pythonfuzz/main.py
@@ -20,11 +20,13 @@ class PythonFuzz(object):
                             help='run the fuzzer through set of files for regression or reproduction')
         parser.add_argument('--rss-limit-mb', type=int, default=2048, help='Memory usage in MB')
         parser.add_argument('--max-input-size', type=int, default=4096, help='Max input size in bytes')
+        parser.add_argument('--dict', type=str, help='dictionary file')
         parser.add_argument('--timeout', type=int, default=30,
                             help='If input takes longer then this timeout the process is treated as failure case')
         args = parser.parse_args()
         f = fuzzer.Fuzzer(self.function, args.dirs, args.exact_artifact_path,
-                          args.rss_limit_mb, args.timeout, args.regression, args.max_input_size)
+                          args.rss_limit_mb, args.timeout, args.regression, args.max_input_size,
+                          args.dict)
         f.start()
 
 


### PR DESCRIPTION
This commits adds the support for dictionaries
(https://llvm.org/docs/LibFuzzer.html#dictionaries), to [help fuzzers increase
their coverage faster]( https://lcamtuf.blogspot.com/2015/01/afl-fuzz-making-up-grammar-with.html ).

It seems that there is a bug in the _copy function, because the word is
correctly inserted, but it seems that the padding after it is wrong,
and I couldn't understand why. Although to be honest,
I didn't spent much time on it, since I'd like to have feedback
on this PR before investing more debug time.

The implementation is pretty crude, it silently ignore
invalid lines in the dictionary file, and is likely using
words in the corpus a bit too often.