### PR TITLE
Fix the arguments order of write_sample

### DIFF
--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -67,7 +67,7 @@ class Fuzzer(object):
             self._total_executions, log_type, self._total_coverage, self._corpus.length, execs_per_second, rss))
         return rss
 
-    def write_sample(self, prefix='crash-', buf):
+    def write_sample(self, buf, prefix='crash-'):
         m = hashlib.sha256()
         m.update(buf)
         if self._exact_artifact_path:
@@ -94,7 +94,7 @@ class Fuzzer(object):
                 self._p.kill()
                 logging.info("=================================================================")
                 logging.info("timeout reached. testcase took: {}".format(self._timeout))
-                self.write_sample(prefix='timeout-', buf)
+                self.write_sample(buf, prefix='timeout-')
                 break
 
             total_coverage = parent_conn.recv()


### PR DESCRIPTION
This was broken by 560c937. This is what happens when you write your code in a virtual-env, and port it to your development copy without testing it.