### PR TITLE
Minor speedup

### DIFF
--- a/pythonfuzz/fuzzer.py
+++ b/pythonfuzz/fuzzer.py
@@ -19,7 +19,7 @@ def worker(target, child_conn):
     cov = coverage.Coverage(branch=True, cover_pylib=True)
     cov.start()
     while True:
-        buf = child_conn.recv()
+        buf = child_conn.recv_bytes()
         try:
             target(buf)
         except Exception as e:
@@ -87,9 +87,10 @@ class Fuzzer(object):
         self._p = mp.Process(target=worker, args=(self._target, child_conn))
         self._p.start()
 
+
         while True:
             buf = self._corpus.generate_input()
-            parent_conn.send(buf)
+            parent_conn.send_bytes(buf)
             if not parent_conn.poll(self._timeout):
                 self._p.kill()
                 logging.info("=================================================================")


### PR DESCRIPTION
Use recv_bytes/send_bytes instead of recv/send
where possible. This yields a bit less than 10% on
my local benchmark, since the fuzzee and the fuzzers
are saving one call to pickle's serialize/unserialize
per cycle.

I'm sure more performances could be obtained by
changing the remaining recv/send calls,
I might give it a try at some point.