### PR TITLE
Add some tests

### DIFF
--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -1,0 +1,17 @@
+import unittest
+import zipfile
+import io
+from unittest.mock import patch
+
+import pythonfuzz
+
+class TestFindCrash(unittest.TestCase):
+    def test_find_crash(self):
+        def fuzz(buf):
+            f = io.BytesIO(buf)
+            z = zipfile.ZipFile(f)
+            z.testzip()
+
+        with patch('logging.Logger.info') as mock:
+            pythonfuzz.fuzzer.Fuzzer(fuzz).start()
+            self.assertTrue(mock.called_once)

--- a/tests/test_nocrash.py
+++ b/tests/test_nocrash.py
@@ -1,0 +1,15 @@
+import unittest
+import zipfile
+import io
+from unittest.mock import patch
+
+import pythonfuzz
+
+class TestFindCrash(unittest.TestCase):
+    def test_find_crash(self):
+        def fuzz(buf):
+            return True
+
+        with patch('logging.Logger.info') as mock:
+            pythonfuzz.fuzzer.Fuzzer(fuzz, runs=100).start()
+            mock.assert_called_with('did %d runs, stopping now.', 100)


### PR DESCRIPTION
This commits adds a test to check if the fuzzer can
find a crash, and to make sure that it doesn't find
anything when the target isn't crashing.

It would be neat to run it automatically on every pull-request (either via travis, gitlab-ci, github action, …) to ensure that nothing breaks :)

We should probably refactor a bit the fuzzer.py file
to make it expose a better API, instead of relying on `logging`.