### PR TITLE
Update .gitignore to ignore pyc files; describe what they're for.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
-.idea
+# Files created by tests
 venv
+*.pyc
 __pycache__
+
+# Files created by general usage
 crash-*
+timeout-*
+
+# Distribution files
 dist/
 build/
 pythonfuzz.egg-info/


### PR DESCRIPTION
The addition of Python 2 (separately) means that we need to ignore the compiled
files that Python 2 creates which are not in the `__pycache__`
directory. This is added to the .gitignore file to make things
consistent.

To make the rest of the file clearer, the sections have been
annotated to show why they're being ignored.

A timeout-* rule has also been added, as this can happen when
there are hangs triggered by the fuzzer.

The .idea exclusion has been removed as it's not generated by
nor anything to do with the product. Users who have use editors
or tools which create files should use the global configuration
of their local system, rather than include them in the
project-specific .gitignore files.