### PR TITLE
Add makefile runner for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# Common User Targets:
+#
+#	make tests
+#		- Sxecute the tests
+#
+#	make shell
+#		- Set up the environment and drop to a shell (re-uses existing shells if they
+#		  have already been set up).
+#		  Use ctrl-d or `exit` to leave the shell.
+#
+#	PYTHON_TOOL=python2 make <target>
+#		- Build the target requested, using python 2
+#
+#
+# Assumptions:
+#	* Python 3 is installed as `python3`. Use the PYTHON_TOOL variable to test using a
+#	  specific python binary.
+#	* The 'virtualenv' tool is installed.
+#
+
+
+PYTHON_TOOL ?= python3
+ACTIVATE = source venv/${PYTHON_TOOL}/bin/activate
+
+.PHONY: tests venv
+
+TEST_MODULES = ${patsubst tests/%.py,%,$(wildcard tests/test_*.py)}
+
+ifeq (${NOCOLOUR},)
+COL_NOTICE = "\\e[35m"
+COL_GOOD = "\\e[32m"
+COL_RESET = "\\e[0m"
+else
+COL_NOTICE = ""
+COL_GOOD = ""
+COL_RESET = ""
+endif
+
+NOTICE = @notice() { printf "\n${COL_NOTICE}+++ %s${COL_RESET}\n" "$$@"; } && notice
+GOOD = @notice() { printf "\n${COL_GOOD}+++ %s${COL_RESET}\n" "$$@"; } && notice
+
+
+tests: test_testable
+	${NOTICE} "Running tests"
+	@# Note: We cd into the tests directory, so that we are testing the installed version, not
+	@# 		the version in the repository.
+	${ACTIVATE} && cd tests && python -munittest -v ${TEST_MODULES}
+	${GOOD} "Tests passed"
+
+venv: venv/successful-${PYTHON_TOOL}
+
+venv/successful-${PYTHON_TOOL}:
+	${NOTICE} "Build the virtualenv we will test within (for ${PYTHON_TOOL})"
+	-rm -rf venv
+	mkdir -p venv
+	virtualenv -p ${PYTHON_TOOL} venv/${PYTHON_TOOL}
+	touch venv/successful-${PYTHON_TOOL}
+
+test_installable: venv
+	${NOTICE} "Check that we can install the product"
+	${ACTIVATE} && python setup.py install
+
+test_testable: test_installable
+	${NOTICE} "Install the test requirements"
+	${ACTIVATE} && pip install -r requirements-test.txt
+
+clean:
+	${NOTICE} "Cleaning temporary files"
+	-rm -rf venv dist build
+	-find . -name '*.pyc' -delete
+	-find . -name '__pycache__' -delete
+	${GOOD} "Cleaned"
+
+shell: venv
+	${NOTICE} "Running shell; use ctrl-d or `exit` to leave"
+	bash -i <<<"${ACTIVATE} && exec < /dev/tty"
+	${GOOD} "Returned to user shell"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+# unittest.mock is present in 3.3 and higher; the mock library provides a backport
+mock==3.0.5 ; python_version < '3.3'

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -1,6 +1,7 @@
+import io
+import os
 import unittest
 import zipfile
-import io
 
 try:
     from unittest.mock import patch
@@ -28,3 +29,10 @@ class TestFindCrash(unittest.TestCase):
         with patch('logging.Logger.info') as mock:
             pythonfuzz.fuzzer.Fuzzer(fuzz).start()
             self.assertTrue(mock.called_once)
+
+            # Check that we created a crash file
+            # (this is the hash of an empty string, because we know that the first call is with an empty string)
+            self.assertTrue(os.path.exists('crash-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'))
+
+            # Clean up after ourselves
+            os.remove('crash-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855')

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -1,12 +1,25 @@
 import unittest
 import zipfile
 import io
-from unittest.mock import patch
 
-import pythonfuzz
+try:
+    from unittest.mock import patch
+except ImportError:
+    # Python 2 backport of mock
+    from mock import patch
+
+import pythonfuzz.fuzzer
+
 
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
+        """
+        Tests that when an Exception occurs in the fuzz function, we detect this.
+
+        Requires that the Fuzzer's configuration causes it to stop when an exception
+        is detected, and that the fuzzer will generate an invalid zip file.
+        Detects the exception implicitly by the fact that a logger call was made.
+        """
         def fuzz(buf):
             f = io.BytesIO(buf)
             z = zipfile.ZipFile(f)

--- a/tests/test_nocrash.py
+++ b/tests/test_nocrash.py
@@ -1,12 +1,22 @@
 import unittest
-import zipfile
-import io
-from unittest.mock import patch
 
-import pythonfuzz
+try:
+    from unittest.mock import patch
+except ImportError:
+    # Python 2 backport of mock
+    from mock import patch
+
+import pythonfuzz.fuzzer
+
 
 class TestFindCrash(unittest.TestCase):
     def test_find_crash(self):
+        """
+        Tests that when no Exception occurs in the fuzz function, we exit without error.
+
+        Detects the exception implicitly by the fact that a logger call was made with
+        particular text.
+        """
         def fuzz(buf):
             return True
 


### PR DESCRIPTION
This change introduces a makefile which can be invoked by users, or by CI systems. It sets up a virtualenv for a specific python, and then using that python installs the package using `python setup.py install` which confirms that it is installable, then installs components that are needed by the tests themselves, and finally executes the tests. It also provides a `clean` and `shell` target, which may help developers to test in the same environment as the tests are run.

The changes here are:

* Created a requirements-test.txt file which is 'the things that we need for testing'.
* Tidied up the crash test so that it both checks that we found the /right/ failure, and cleans up after itself.
* Created a Makefile to automate the invocation of the tests in a suitable test environment.

Makefile targets:
* `make tests` to run the tests, or `make tests PYTHON_TOOL=<your python>` to tests with a specific python (eg `python2`).
* `make shell` drops you to a bash shell in the environment it was testing in, so you can work with what the makefile thinks its testing against.
* `make clean` removes the junk and the test environment so you can hopefully be sure it's going to work reliably for others.
