### PR TITLE
Add mutator unittests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,8 @@ ACTIVATE = source venv/${PYTHON_TOOL}/bin/activate
 
 .PHONY: tests venv
 
-TEST_MODULES = ${patsubst tests/%.py,%,$(wildcard tests/test_*.py)}
+UNITTEST_MODULES = ${patsubst tests/%.py,%,$(wildcard tests/unittest_*.py)}
+INTTEST_MODULES = ${patsubst tests/%.py,%,$(wildcard tests/test_*.py)}
 
 ifeq (${NOCOLOUR},)
 COL_NOTICE = "\\e[35m"
@@ -51,14 +52,17 @@ test_level_system: test_level_integration systemtests
 # Unit tests test individual parse of a small unit.
 unittests: test_testable
 	${NOTICE} "Running unit tests"
-	${GOOD} "Unit tests passed (we don't have any yet)"
+	@# Note: We cd into the tests directory, so that we are testing the installed version, not
+	@# 		the version in the repository.
+	${ACTIVATE} && cd tests && python -munittest -v ${UNITTEST_MODULES}
+	${GOOD} "Unit tests passed"
 
 # Integration tests check the integration of those units.
 integrationtests: test_testable
 	${NOTICE} "Running integration tests"
 	@# Note: We cd into the tests directory, so that we are testing the installed version, not
 	@# 		the version in the repository.
-	${ACTIVATE} && cd tests && python -munittest -v ${TEST_MODULES}
+	${ACTIVATE} && cd tests && python -munittest -v ${INTTEST_MODULES}
 	${GOOD} "Integration tests passed"
 
 # System tests check that the way that a user might use it works.

--- a/examples/run_all_examples.py
+++ b/examples/run_all_examples.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 """
 Run all the examples and collect the timings and results.
+
+SUT:    Invocation
+Area:   Examples run
+Class:  Functional
+Type:   System test
 """
 
 import argparse

--- a/tests/test_crash.py
+++ b/tests/test_crash.py
@@ -1,3 +1,12 @@
+"""
+Test the fuzzing terminates when a fault is found.
+
+SUT:    Fuzzer
+Area:   Fault finding
+Class:  Functional
+Type:   Integration test
+"""
+
 import io
 import os
 import unittest

--- a/tests/test_nocrash.py
+++ b/tests/test_nocrash.py
@@ -1,3 +1,12 @@
+"""
+Test the fuzzing terminates when no faults found, at a run limit.
+
+SUT:    Fuzzer
+Area:   Non-fault operation
+Class:  Functional
+Type:   Integration test
+"""
+
 import unittest
 
 try:

--- a/tests/unittest_mutators.py
+++ b/tests/unittest_mutators.py
@@ -1,0 +1,198 @@
+import unittest
+
+try:
+    from unittest.mock import patch
+except ImportError:
+    # Python 2 backport of mock
+    from mock import patch
+
+import pythonfuzz.corpus as corpus
+
+
+class FakeCorpus(object):
+    pass
+
+
+class BaseTestMutators(unittest.TestCase):
+    """
+    Test that the mutators objects are doing what we want them to do.
+    """
+    # Subclasses should set this - 'mutator' will be created as part of setup.
+    mutator_class = None
+
+    def setUp(self):
+        self.corpus = FakeCorpus()
+        self.patch_rand = patch('pythonfuzz.corpus.Mutator._rand')
+        self.mock_rand = self.patch_rand.start()
+        self.mock_rand.side_effect = []
+        # Update the side effects in your subclass
+
+        self.addCleanup(self.patch_rand.stop)
+
+        self.mutator = self.mutator_class(self.corpus)
+
+
+class TestMutatorRemoveRange(BaseTestMutators):
+    mutator_class = corpus.MutatorRemoveRange
+
+    def test01_empty(self):
+        # You cannot remove values from an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_remove_section(self):
+        # Check that it removes a sensible range
+
+        # Check that removing at the 2nd position, removing 4 characters leaves the right string.
+        self.mock_rand.side_effect = [2, 0, 3]
+
+        res = self.mutator.mutate(bytearray(b'1234567890'))
+        self.assertEqual(res, bytearray(b'127890'))
+
+
+class TestMutatorInsertBytes(BaseTestMutators):
+    mutator_class = corpus.MutatorInsertBytes
+
+    def test02_insert_bytes(self):
+        # Check that it inserts sensibly
+
+        # Check that inserting at the 2nd position, adding 4 characters gives us the right string
+        self.mock_rand.side_effect = [2, 0, 3, 65, 66, 67, 68]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'12ABCD3456789'))
+
+
+class TestMutatorDuplicateBytes(BaseTestMutators):
+    mutator_class = corpus.MutatorDuplicateBytes
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_duplicate_bytes(self):
+        # Check that it duplicates
+
+        # Duplicate from offset 2 to offset 5, length 2
+        self.mock_rand.side_effect = [2, 5, 0, 1]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'12345346789'))
+
+
+class TestMutatorCopyBytes(BaseTestMutators):
+    mutator_class = corpus.MutatorDuplicateBytes
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_duplicate_bytes(self):
+        # Check that it duplicates
+
+        # Duplicate from offset 2 to offset 5, length 2
+        self.mock_rand.side_effect = [2, 5, 0, 1]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'12345346789'))
+
+
+class TestMutatorBitFlip(BaseTestMutators):
+    mutator_class = corpus.MutatorBitFlip
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_flip_bit(self):
+        # Check that it flips
+
+        # At offset 4, flip bit 3
+        self.mock_rand.side_effect = [4, 3]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'1234=6789'))
+
+
+class TestMutatorRandomiseByte(BaseTestMutators):
+    mutator_class = corpus.MutatorRandomiseByte
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_randomise_byte(self):
+        # Check that it changes a byte
+
+        # At offset 4, EOR with 65+1
+        self.mock_rand.side_effect = [4, 65]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'1234w6789'))
+
+
+class TestMutatorSwapBytes(BaseTestMutators):
+    mutator_class = corpus.MutatorSwapBytes
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_swap_bytes(self):
+        # Check that it swaps bytes
+
+        # Swap bytes at 1 and 6
+        self.mock_rand.side_effect = [1, 6]
+
+        res = self.mutator.mutate(bytearray(b'123456789'))
+        self.assertEqual(res, bytearray(b'173456289'))
+
+
+class TestMutatorAddSubByte(BaseTestMutators):
+    mutator_class = corpus.MutatorAddSubByte
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_add_bytes(self):
+        # Check that it adds/subs
+        # FIXME: Not yet implemented - uses a randomised bit for the add/sub
+        pass
+
+# FIXME: Also not implemented AddSubShort, AddSubLong, AddSubLongLong
+# FIXME: Not yet implemented ReplaceByte, ReplaceShort, ReplaceLong
+
+
+class TestMutatorReplaceDigit(BaseTestMutators):
+    mutator_class = corpus.MutatorReplaceDigit
+
+    def test01_empty(self):
+        # Cannot work with an empty input
+        res = self.mutator.mutate(bytearray(b''))
+        self.assertIsNone(res)
+
+    def test02_no_digits(self):
+        # Cannot work with a string that has no digits
+        res = self.mutator.mutate(bytearray(b'wibble'))
+        self.assertIsNone(res)
+
+    def test03_replace_digit(self):
+        # Check that it replaces a digit
+        self.mock_rand.side_effect = [0, 5]
+
+        res = self.mutator.mutate(bytearray(b'there are 4 lights'))
+        self.assertEqual(res, bytearray(b'there are 5 lights'))
+
+
+# FIXME: Not yet implemented: Dictionary insert, Dictionary Append
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unittest_mutators.py
+++ b/tests/unittest_mutators.py
@@ -1,3 +1,12 @@
+"""
+Test the mutators operate as desired.
+
+SUT:    Corpus
+Area:   Mutators
+Class:  Functional
+Type:   Unit test
+"""
+
 import unittest
 
 try:


### PR DESCRIPTION
This PR requires PR #26,. #27, #28, #29 and #30 to be merged first.

This change adds unit tests for some of the mutators, and addresses some issues that were found when the mutators were being tested.

The mutators are tested with the 'unittest' level of testing, meaning that they only invoke the unit of the module, and should not be affected by anything outside that module. As such they're very limited. Although they test only a couple of cases for each mutator they have found problems because the operation they were expected to perform hasn't worked.

This PR comprises 3 changes:

* Adding the unit tests, and fixing a few issues found along the way.
* Updating the Makefile to use these unit tests.
* Adding an annotation to each of the testing files to describe where they fit into the testing of the product.

The latter of these could be independant, or dropped; it has been useful to me.