### PR TITLE
Get rid of coverage.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ PythonFuzz is a port of [fuzzitdev/jsfuzz](https://github.com/fuzzitdev/jsfuzz)
 which is in turn heavily based on [go-fuzz](https://github.com/dvyukov/go-fuzz) originally developed by [Dmitry Vyukov's](https://twitter.com/dvyukov).
 Which is in turn heavily based on [Michal Zalewski](https://twitter.com/lcamtuf) [AFL](http://lcamtuf.coredump.cx/afl/).
 
-For coverage PythonFuzz is using [coverage](https://coverage.readthedocs.io/en/v4.5.x/) instrumentation and coverage library. 
-
 ## Contributions
 
 Contributions are welcome!:) There are still a lot of things to improve, and tests and features to add. We will slowly post those in the

--- a/pythonfuzz/tracer.py
+++ b/pythonfuzz/tracer.py
@@ -1,0 +1,36 @@
+import collections
+import sys
+
+prev_line = 0
+prev_filename = ''
+data = collections.defaultdict(set)
+
+def trace(frame, event, arg):
+    if event != 'line':
+        return trace
+
+    global prev_line
+    global prev_filename
+
+    func_filename = frame.f_code.co_filename
+    func_line_no = frame.f_lineno
+
+    if func_filename != prev_filename:
+        # We need a way to keep track of inter-files transferts,
+        # and since we don't really care about the details of the coverage,
+        # concatenating the two filenames in enough.
+        data[func_filename + prev_filename].add((prev_line, func_line_no))
+    else:
+        data[func_filename].add((prev_line, func_line_no))
+
+    prev_line = func_line_no
+    prev_filename = func_filename
+
+    return trace
+
+
+def get_coverage():
+    ret = 0
+    for value in data.values():
+        ret += len(value)
+    return ret

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-coverage==4.5.4
 psutil==5.6.3
 numpy==1.16.6; python_version < '3'
 numpy==1.17.3; python_version >= '3'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setuptools.setup(
     url="https://github.com/fuzzitdev/pythonfuzz",
     install_requires=[
         # WARNING: Keep these values in line with those in requirements.txt
-        "coverage==4.5.4",
         "psutil==5.6.3",
         "numpy==1.16.6; python_version < '3'",
         "numpy==1.17.3; python_version >= '3'",


### PR DESCRIPTION
Coverage.py does a lot of funky things that we don't
care about, and while its trace function is written in C
and is super-fast-fuck-yeah, since it's using a sqlite
database to store everything, gathering coverage is _slow_.

A simple'n'stupid pure-python implementation of
edges-coverage yields 4 times more exec/s on my laptop.

This will also allow in the future to use other
kind of metrics to guide the fuzzer, like
the depth of the calltrace for example,
or to have triples instead of pairs for the edges, …