### PR TITLE
Significantly speed up coverage collection

### DIFF
--- a/pythonfuzz/tracer.py
+++ b/pythonfuzz/tracer.py
@@ -30,7 +30,4 @@ def trace(frame, event, arg):
 
 
 def get_coverage():
-    ret = 0
-    for value in data.values():
-        ret += len(value)
-    return ret
+    return sum(map(len, data.values()))


### PR DESCRIPTION
This reduces the time spent in get_coverage from ~30% to ~2% in my local tests on Python3.