### PR TITLE
Add mutagen in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,6 @@ any unnecessary work is done.
 
 * [python built-in HTMLParser - unhandled exception](https://bugs.python.org/msg355287)
 * [CleverCSV - unhandled exceptions](https://github.com/alan-turing-institute/CleverCSV/issues/7)
+* [Mutagen - unhandled exceptions and timeouts]( https://github.com/quodlibet/mutagen/issues?q=+is%3Aissue+author%3Ajvoisin+ ) 
 
 **Feel free to add bugs that you found with pythonfuzz to this list via pull-request**


### PR DESCRIPTION
I've found a lot of unhandled exceptions and timeouts
in mutagen by fuzzing it with PythonFuzz.